### PR TITLE
Ignore __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 *.log
 *.log.*
+**/__pycache__/


### PR DESCRIPTION
Hello,

After running `python main.py`, some `__pycache__` subdirectories are created. So I propose to ignore them:

``` bash
$ git satus
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
          openspectra/__pycache__/
          openspectra/ui/__pycache__/
```